### PR TITLE
fix: Script pathing issues and input, output mapping null JSON object

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -36,7 +36,7 @@ locals {
     storage = (var.input_tables != null || var.output_tables != null) ? {
       input  = var.input_tables  # jsonencode will omit this field if var.input_tables is null
       output = var.output_tables # jsonencode will omit this field if var.output_tables is null
-    } : null # Storage block is null if neither input_tables nor output_tables are provided
+    } : {} # Storage block is null if neither input_tables nor output_tables are provided
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
   # Read script content if a path is provided. The path is relative to this module's directory.
-  script_content = var.sql_script_path != null ? file("${path.module}/${var.sql_script_path}") : null
+  script_content = var.sql_script_path != null ? file(var.sql_script_path) : null
 
   # Process scripts based on component type.
   # For Python transformations, the entire file content is treated as a single script.


### PR DESCRIPTION
```
╷
│ Error: Invalid function argument
│ 
│   on .terraform/modules/snowflake_transformation_generator_10m_texts/main.tf line 3, in locals:
│    3:   script_content = var.sql_script_path != null ? file("${path.module}/${var.sql_script_path}") : null
│     ├────────────────
│     │ while calling file(path)
│     │ path.module is ".terraform/modules/snowflake_transformation_generator_10m_texts"
│     │ var.sql_script_path is "../../terraform/generate.sql"
│ 
│ Invalid value for "path" parameter: no file exists at 
```
* Fixes issue with `path.module` which was not present outside module usage. Now you can use script_path as follows:
```
sql_script_path = "./generate.sql"
```
* Fix issue with input and output mapping null vs empty JSON object